### PR TITLE
Redesign file IPC with session management and single gamestate file

### DIFF
--- a/OpenRA.LLMHarness/LLMHarnessOptions.cs
+++ b/OpenRA.LLMHarness/LLMHarnessOptions.cs
@@ -6,6 +6,7 @@ namespace OpenRA.LLMHarness
 		public string LogDirectory { get; set; } = @"C:\OpenRATest\LLM_Coach_Logs";
 		public string OrderInputDirectory { get; set; } = @"C:\OpenRATest_Orders\input";
 		public string OrderArchiveDirectory { get; set; } = @"C:\OpenRATest_Orders\archive";
+		public string SessionsDirectory { get; set; } = "sessions";
 		public string OllamaApiUrl { get; set; } = "http://localhost:11434/v1";
 		public string ModelName { get; set; } = "phi4:14b";
 	}

--- a/OpenRA.LLMHarness/Pages/Index.razor
+++ b/OpenRA.LLMHarness/Pages/Index.razor
@@ -42,23 +42,16 @@
             }
             else
             {
-                <MudList Clickable="true">
+                <MudList Clickable="true" Dense="true">
                     @foreach (var response in sessionHistory.OrderByDescending(r => r.Timestamp))
                     {
-                        <MudListItem OnClick="@(() => SelectResponse(response.Id))">
-                            <MudCard Outlined="@(selectedResponseId == response.Id)" 
-                                     Class="@(selectedResponseId == response.Id ? "mud-theme-primary" : "")">
-                                <MudCardContent Class="py-2 px-3">
-                                    <MudText Typo="Typo.caption">@response.Timestamp.ToString("HH:mm:ss")</MudText>
-                                    <MudText Typo="Typo.body2" Class="text-truncate">
-                                        @(response.Response.Length > 50 ? response.Response.Substring(0, 50) + "..." : response.Response)
-                                    </MudText>
-                                    <MudText Typo="Typo.caption" Color="Color.Secondary">
-                                        @response.DurationSeconds.ToString("F1")s
-                                    </MudText>
-                                </MudCardContent>
-                            </MudCard>
+                        <MudListItem OnClick="@(() => SelectResponse(response.Id))"
+                                     Selected="@(selectedResponseId == response.Id)">
+                            <MudText Typo="Typo.body2">
+                                @response.Timestamp.ToString("HH:mm:ss") - @response.DurationSeconds.ToString("F1")s
+                            </MudText>
                         </MudListItem>
+                        <MudDivider />
                     }
                 </MudList>
             }

--- a/OpenRA.LLMHarness/Pages/Index.razor
+++ b/OpenRA.LLMHarness/Pages/Index.razor
@@ -1,6 +1,7 @@
 @page "/"
 @using OpenRA.LLMHarness.Services
 @inject OllamaService OllamaService
+@inject SessionManager SessionManager
 @inject IJSRuntime JSRuntime
 @implements IDisposable
 
@@ -111,7 +112,40 @@
                 </MudItem>
             </MudGrid>
             <MudDivider Class="my-4" />
-            
+
+            <!-- Session Control -->
+            <MudCard Class="mb-4">
+                <MudCardContent>
+                    <MudText Typo="Typo.h6" Class="mb-2">Session Management</MudText>
+                    @if (SessionManager.IsSessionActive)
+                    {
+                        <MudAlert Severity="Severity.Success" Class="mb-3">
+                            <strong>Session Active:</strong> @SessionManager.CurrentSessionId
+                            <br/>
+                            Turns: @SessionManager.TurnCount | Duration: @FormatDuration(SessionManager.SessionDuration)
+                        </MudAlert>
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Error"
+                                   OnClick="StopSession"
+                                   StartIcon="@Icons.Material.Filled.Stop">
+                            Stop Session
+                        </MudButton>
+                    }
+                    else
+                    {
+                        <MudAlert Severity="Severity.Warning" Class="mb-3">
+                            No active session. Start a session before beginning a match.
+                        </MudAlert>
+                        <MudButton Variant="Variant.Filled"
+                                   Color="Color.Success"
+                                   OnClick="StartSession"
+                                   StartIcon="@Icons.Material.Filled.PlayArrow">
+                            Start New Session
+                        </MudButton>
+                    }
+                </MudCardContent>
+            </MudCard>
+
             <!-- Human message input -->
             <MudCard Class="mb-4">
                 <MudCardContent>
@@ -436,6 +470,47 @@
         humanMessageDraft = "";
         OllamaService.HumanMessage = "";
         isEditingHumanMessage = false;
+    }
+
+    // Session management methods
+    private void StartSession()
+    {
+        try
+        {
+            SessionManager.StartSession();
+            statusMessage = $"Session started: {SessionManager.CurrentSessionId}";
+        }
+        catch (Exception ex)
+        {
+            statusMessage = $"Failed to start session: {ex.Message}";
+        }
+    }
+
+    private void StopSession()
+    {
+        try
+        {
+            SessionManager.StopSession();
+            statusMessage = "Session stopped";
+        }
+        catch (Exception ex)
+        {
+            statusMessage = $"Failed to stop session: {ex.Message}";
+        }
+    }
+
+    private string FormatDuration(TimeSpan? duration)
+    {
+        if (!duration.HasValue)
+            return "N/A";
+
+        var d = duration.Value;
+        if (d.TotalMinutes < 1)
+            return $"{d.Seconds}s";
+        else if (d.TotalHours < 1)
+            return $"{d.Minutes}m {d.Seconds}s";
+        else
+            return $"{d.Hours}h {d.Minutes}m";
     }
 
     public void Dispose()

--- a/OpenRA.LLMHarness/Program.cs
+++ b/OpenRA.LLMHarness/Program.cs
@@ -27,6 +27,10 @@ builder.Services.AddHostedService<FileWatcherService>();
 
 var app = builder.Build();
 
+// Clean up orphaned session marker file if harness crashed previously
+var sessionManager = app.Services.GetRequiredService<SessionManager>();
+sessionManager.CleanupOrphanedMarker();
+
 // Configure the HTTP request pipeline.
 if (!app.Environment.IsDevelopment())
 {

--- a/OpenRA.LLMHarness/Program.cs
+++ b/OpenRA.LLMHarness/Program.cs
@@ -16,6 +16,9 @@ builder.Services.Configure<LLMHarnessOptions>(
 // Add HttpClient for OllamaService
 builder.Services.AddHttpClient<OllamaService>();
 
+// Add SessionManager as a singleton
+builder.Services.AddSingleton<SessionManager>();
+
 // Add OllamaService as a singleton
 builder.Services.AddSingleton<OllamaService>();
 

--- a/OpenRA.LLMHarness/Services/OllamaService.cs
+++ b/OpenRA.LLMHarness/Services/OllamaService.cs
@@ -12,6 +12,7 @@ namespace OpenRA.LLMHarness.Services
 		readonly string logDirectory;
 		readonly string orderInputDirectory;
 		readonly string orderArchiveDirectory;
+		readonly SessionManager sessionManager;
 		// Note: phi4:14b and llama3.1:8b work very well, 5 to 10 seconds per response and they produce the correct order format more consistently.
 		public string OllamaApiUrl { get; set; }
 		public string ModelName { get; set; }
@@ -43,7 +44,7 @@ namespace OpenRA.LLMHarness.Services
 		public event Func<LLMResponse, Task>? OnResponseComplete;
 		public event Func<string, Task>? OnStatusUpdate;
 
-		public OllamaService(HttpClient httpClient, IOptions<LLMHarnessOptions> options)
+		public OllamaService(HttpClient httpClient, IOptions<LLMHarnessOptions> options, SessionManager sessionManager)
 		{
 			var config = options.Value;
 			watchDirectory = config.WatchDirectory;
@@ -52,6 +53,7 @@ namespace OpenRA.LLMHarness.Services
 			orderArchiveDirectory = config.OrderArchiveDirectory;
 			OllamaApiUrl = config.OllamaApiUrl;
 			ModelName = config.ModelName;
+			this.sessionManager = sessionManager;
 
 			InitializeChatClient();
 		}
@@ -346,11 +348,19 @@ namespace OpenRA.LLMHarness.Services
 		private async Task ProcessFileAsync(string filePath)
 		{
 			await LogToFileAsync($"[PROCESS_FILE] Starting ProcessFileAsync for: {Path.GetFileName(filePath)}");
-			
+
 			// Check if we're shutting down
 			if (shutdownCts?.Token.IsCancellationRequested ?? true)
 			{
 				await LogToFileAsync($"[PROCESS_FILE] Skipping {Path.GetFileName(filePath)} - shutdown requested");
+				return;
+			}
+
+			// Check if a session is active
+			if (!sessionManager.IsSessionActive)
+			{
+				await LogToFileAsync($"[PROCESS_FILE] Skipping {Path.GetFileName(filePath)} - no active session");
+				await NotifyStatusAsync("No active session - please start a session to process game states");
 				return;
 			}
 
@@ -616,6 +626,28 @@ namespace OpenRA.LLMHarness.Services
 						DurationSeconds = seconds
 					};
 					await OnResponseComplete(llmResponse);
+				}
+
+				// Save turn artifacts to session
+				if (sessionManager.IsSessionActive)
+				{
+					try
+					{
+						var turnPath = sessionManager.SaveTurn(
+							systemPrompt,
+							userPrompt,
+							fullResponse,
+							ModelName,
+							ThinkingLevel,
+							seconds,
+							seconds); // Use same value for total pipeline time for now
+
+						await LogToFileAsync($"[SESSION] Saved turn artifacts to: {turnPath}");
+					}
+					catch (Exception ex)
+					{
+						await LogToFileAsync($"[SESSION] Failed to save turn artifacts: {ex.Message}\n{ex.StackTrace}");
+					}
 				}
 			}
 			catch (OperationCanceledException)

--- a/OpenRA.LLMHarness/Services/OllamaService.cs
+++ b/OpenRA.LLMHarness/Services/OllamaService.cs
@@ -18,7 +18,7 @@ namespace OpenRA.LLMHarness.Services
 		public string ModelName { get; set; }
 
 		ChatClient chatClient;
-		readonly HashSet<string> processedFiles = [];
+		readonly Dictionary<string, DateTime> processedFiles = new();
 
 		public bool VerboseMode { get; set; } = false;
 		public string ThinkingLevel { get; set; } = "medium";
@@ -318,23 +318,35 @@ namespace OpenRA.LLMHarness.Services
 					return;
 				}
 
-				// Check if the most recent file needs processing
+				// Check if the most recent file needs processing based on timestamp
 				var mostRecentFile = files.First();
 				var fileTime = File.GetLastWriteTime(mostRecentFile);
-				
-				// If the file is newer than our last processed time and not in processedFiles
+
+				// Check if file has been updated since we last processed it
 				bool shouldProcess = false;
 				lock (processedFiles)
 				{
-					if (!processedFiles.Contains(mostRecentFile) && fileTime > lastFileProcessedTime)
+					if (processedFiles.TryGetValue(mostRecentFile, out var lastProcessedTime))
 					{
-						shouldProcess = true;
+						// File was processed before - check if it's been updated since
+						if (fileTime > lastProcessedTime)
+						{
+							shouldProcess = true;
+						}
+					}
+					else
+					{
+						// File never processed - check if it's newer than our last activity
+						if (fileTime > lastFileProcessedTime)
+						{
+							shouldProcess = true;
+						}
 					}
 				}
 
 				if (shouldProcess && !isProcessingLLM)
 				{
-					await LogToFileAsync($"[FALLBACK] Found unprocessed file: {Path.GetFileName(mostRecentFile)}");
+					await LogToFileAsync($"[FALLBACK] Found unprocessed or updated file: {Path.GetFileName(mostRecentFile)}");
 					await ProcessFileAsync(mostRecentFile);
 				}
 			}
@@ -364,14 +376,22 @@ namespace OpenRA.LLMHarness.Services
 				return;
 			}
 
-			// Check if already processed first
+			// Check if already processed based on file timestamp
+			var fileLastWriteTime = File.GetLastWriteTime(filePath);
 			bool alreadyProcessed = false;
 			lock (processedFiles)
 			{
-				if (processedFiles.Contains(filePath))
+				if (processedFiles.TryGetValue(filePath, out var lastProcessedTime))
 				{
-					alreadyProcessed = true;
-					_ = LogToFileAsync($"[PROCESS_FILE] Skipping {Path.GetFileName(filePath)} - already in processedFiles set (total: {processedFiles.Count})");
+					if (fileLastWriteTime <= lastProcessedTime)
+					{
+						alreadyProcessed = true;
+						_ = LogToFileAsync($"[PROCESS_FILE] Skipping {Path.GetFileName(filePath)} - file not modified since last processing (last: {lastProcessedTime:HH:mm:ss.fff}, current: {fileLastWriteTime:HH:mm:ss.fff})");
+					}
+					else
+					{
+						_ = LogToFileAsync($"[PROCESS_FILE] File {Path.GetFileName(filePath)} has been updated (last: {lastProcessedTime:HH:mm:ss.fff}, current: {fileLastWriteTime:HH:mm:ss.fff})");
+					}
 				}
 			}
 
@@ -390,12 +410,12 @@ namespace OpenRA.LLMHarness.Services
 					return;
 				}
 
-				// We got the lock, now mark this file as processed
+				// We got the lock, now mark this file as processed with its timestamp
 				isProcessingLLM = true;
 				lock (processedFiles)
 				{
-					processedFiles.Add(filePath);
-					_ = LogToFileAsync($"[PROCESS_FILE] Added {Path.GetFileName(filePath)} to processedFiles set (total: {processedFiles.Count})");
+					processedFiles[filePath] = fileLastWriteTime;
+					_ = LogToFileAsync($"[PROCESS_FILE] Recorded {Path.GetFileName(filePath)} with timestamp {fileLastWriteTime:HH:mm:ss.fff} (total tracked: {processedFiles.Count})");
 				}
 				_ = LogToFileAsync($"[LOCK] Starting processing for: {Path.GetFileName(filePath)}");
 			}

--- a/OpenRA.LLMHarness/Services/SessionManager.cs
+++ b/OpenRA.LLMHarness/Services/SessionManager.cs
@@ -1,0 +1,163 @@
+using System.Reflection;
+using System.Text.Json;
+using Microsoft.Extensions.Options;
+
+namespace OpenRA.LLMHarness.Services
+{
+	public sealed class SessionManager
+	{
+		readonly string sessionsBaseDirectory;
+		string? currentSessionId;
+		string? currentSessionPath;
+		DateTime? sessionStartTime;
+		int turnCounter = 0;
+		readonly string sessionMarkerFile;
+
+		public bool IsSessionActive => currentSessionId != null;
+		public string? CurrentSessionId => currentSessionId;
+		public int TurnCount => turnCounter;
+		public TimeSpan? SessionDuration => sessionStartTime.HasValue ? DateTime.Now - sessionStartTime.Value : null;
+
+		public SessionManager(IOptions<LLMHarnessOptions> options)
+		{
+			var config = options.Value;
+
+			// Resolve sessions directory - if relative, make it relative to project root (not bin/)
+			if (Path.IsPathRooted(config.SessionsDirectory))
+			{
+				sessionsBaseDirectory = config.SessionsDirectory;
+			}
+			else
+			{
+				// Get project root by going up from bin/Debug/net8.0 to project directory
+				var assemblyLocation = Assembly.GetExecutingAssembly().Location;
+				var binDirectory = Path.GetDirectoryName(assemblyLocation);
+				var projectRoot = Path.GetFullPath(Path.Combine(binDirectory!, "..", "..", ".."));
+				sessionsBaseDirectory = Path.Combine(projectRoot, config.SessionsDirectory);
+			}
+
+			// Session marker file goes in watch directory
+			sessionMarkerFile = Path.Combine(config.WatchDirectory, ".session_active");
+
+			// Ensure base sessions directory exists
+			if (!Directory.Exists(sessionsBaseDirectory))
+			{
+				Directory.CreateDirectory(sessionsBaseDirectory);
+			}
+		}
+
+		public string StartSession()
+		{
+			if (IsSessionActive)
+				throw new InvalidOperationException("A session is already active. Stop the current session before starting a new one.");
+
+			currentSessionId = Guid.NewGuid().ToString("N")[..8]; // Short GUID for readability
+			sessionStartTime = DateTime.Now;
+			turnCounter = 0;
+
+			// Create session folder: YYYYMMDD_HHMMSS_{guid}
+			var timestamp = sessionStartTime.Value.ToString("yyyyMMdd_HHmmss");
+			var folderName = $"{timestamp}_{currentSessionId}";
+			currentSessionPath = Path.Combine(sessionsBaseDirectory, folderName);
+
+			// Create directory structure
+			Directory.CreateDirectory(currentSessionPath);
+			Directory.CreateDirectory(Path.Combine(currentSessionPath, "turns"));
+
+			// Write session marker file for game to detect
+			File.WriteAllText(sessionMarkerFile, currentSessionId);
+
+			return currentSessionId;
+		}
+
+		public void StopSession()
+		{
+			if (!IsSessionActive)
+				return;
+
+			// Write final session metadata
+			var metadata = new
+			{
+				session_id = currentSessionId,
+				start_time = sessionStartTime,
+				end_time = DateTime.Now,
+				turn_count = turnCounter,
+				total_duration_seconds = SessionDuration?.TotalSeconds ?? 0
+			};
+
+			var metadataPath = Path.Combine(currentSessionPath!, "session_metadata.json");
+			File.WriteAllText(metadataPath, JsonSerializer.Serialize(metadata, new JsonSerializerOptions { WriteIndented = true }));
+
+			// Remove session marker file
+			if (File.Exists(sessionMarkerFile))
+			{
+				File.Delete(sessionMarkerFile);
+			}
+
+			// Clear session state
+			currentSessionId = null;
+			currentSessionPath = null;
+			sessionStartTime = null;
+			turnCounter = 0;
+		}
+
+		public string SaveTurn(
+			string systemPrompt,
+			string userMessage,
+			string assistantResponse,
+			string modelName,
+			string thinkingLevel,
+			double llmLatencySeconds,
+			double totalPipelineSeconds)
+		{
+			if (!IsSessionActive)
+				throw new InvalidOperationException("No active session. Start a session before saving turns.");
+
+			turnCounter++;
+			var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
+			var turnFolderName = $"turn_{turnCounter:D3}_{timestamp}";
+			var turnPath = Path.Combine(currentSessionPath!, "turns", turnFolderName);
+
+			Directory.CreateDirectory(turnPath);
+
+			// Save prompts and response as markdown
+			File.WriteAllText(Path.Combine(turnPath, "system_prompt.md"), systemPrompt);
+			File.WriteAllText(Path.Combine(turnPath, "user_message.md"), userMessage);
+			File.WriteAllText(Path.Combine(turnPath, "assistant_response.md"), assistantResponse);
+
+			// Save settings
+			var settings = new
+			{
+				turn_number = turnCounter,
+				timestamp = DateTime.Now,
+				model = modelName,
+				thinking_level = thinkingLevel
+			};
+			File.WriteAllText(
+				Path.Combine(turnPath, "settings.json"),
+				JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true }));
+
+			// Save timing
+			var timing = new
+			{
+				timestamp = DateTime.Now,
+				llm_latency_seconds = llmLatencySeconds,
+				total_pipeline_seconds = totalPipelineSeconds
+			};
+			File.WriteAllText(
+				Path.Combine(turnPath, "timing.json"),
+				JsonSerializer.Serialize(timing, new JsonSerializerOptions { WriteIndented = true }));
+
+			return turnPath;
+		}
+
+		public void CleanupOrphanedMarker()
+		{
+			// Called on startup to clean up marker file if harness crashed
+			if (File.Exists(sessionMarkerFile) && !IsSessionActive)
+			{
+				File.Delete(sessionMarkerFile);
+			}
+		}
+	}
+}

--- a/OpenRA.LLMHarness/Services/SessionManager.cs
+++ b/OpenRA.LLMHarness/Services/SessionManager.cs
@@ -22,18 +22,20 @@ namespace OpenRA.LLMHarness.Services
 		{
 			var config = options.Value;
 
-			// Resolve sessions directory - if relative, make it relative to project root (not bin/)
+			// Resolve sessions directory - if relative, make it relative to LLMHarness project folder
 			if (Path.IsPathRooted(config.SessionsDirectory))
 			{
 				sessionsBaseDirectory = config.SessionsDirectory;
 			}
 			else
 			{
-				// Get project root by going up from bin/Debug/net8.0 to project directory
+				// Assembly is at /project/bin/OpenRA.LLMHarness.dll
+				// We want /project/OpenRA.LLMHarness/sessions/
 				var assemblyLocation = Assembly.GetExecutingAssembly().Location;
 				var binDirectory = Path.GetDirectoryName(assemblyLocation);
-				var projectRoot = Path.GetFullPath(Path.Combine(binDirectory!, "..", "..", ".."));
-				sessionsBaseDirectory = Path.Combine(projectRoot, config.SessionsDirectory);
+				var projectRoot = Path.GetFullPath(Path.Combine(binDirectory!, ".."));
+				var harnessProjectDir = Path.Combine(projectRoot, "OpenRA.LLMHarness");
+				sessionsBaseDirectory = Path.Combine(harnessProjectDir, config.SessionsDirectory);
 			}
 
 			// Session marker file goes in watch directory
@@ -60,9 +62,8 @@ namespace OpenRA.LLMHarness.Services
 			var folderName = $"{timestamp}_{currentSessionId}";
 			currentSessionPath = Path.Combine(sessionsBaseDirectory, folderName);
 
-			// Create directory structure
+			// Create session directory
 			Directory.CreateDirectory(currentSessionPath);
-			Directory.CreateDirectory(Path.Combine(currentSessionPath, "turns"));
 
 			// Write session marker file for game to detect
 			File.WriteAllText(sessionMarkerFile, currentSessionId);
@@ -115,15 +116,11 @@ namespace OpenRA.LLMHarness.Services
 
 			turnCounter++;
 			var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
-			var turnFolderName = $"turn_{turnCounter:D3}_{timestamp}";
-			var turnPath = Path.Combine(currentSessionPath!, "turns", turnFolderName);
 
-			Directory.CreateDirectory(turnPath);
-
-			// Save prompts and response as markdown
-			File.WriteAllText(Path.Combine(turnPath, "system_prompt.md"), systemPrompt);
-			File.WriteAllText(Path.Combine(turnPath, "user_message.md"), userMessage);
-			File.WriteAllText(Path.Combine(turnPath, "assistant_response.md"), assistantResponse);
+			// Save prompts and response as markdown with timestamped filenames
+			File.WriteAllText(Path.Combine(currentSessionPath!, $"{timestamp}_system_prompt.md"), systemPrompt);
+			File.WriteAllText(Path.Combine(currentSessionPath!, $"{timestamp}_user_message.md"), userMessage);
+			File.WriteAllText(Path.Combine(currentSessionPath!, $"{timestamp}_assistant_response.md"), assistantResponse);
 
 			// Save settings
 			var settings = new
@@ -134,7 +131,7 @@ namespace OpenRA.LLMHarness.Services
 				thinking_level = thinkingLevel
 			};
 			File.WriteAllText(
-				Path.Combine(turnPath, "settings.json"),
+				Path.Combine(currentSessionPath!, $"{timestamp}_settings.json"),
 				JsonSerializer.Serialize(settings, new JsonSerializerOptions { WriteIndented = true }));
 
 			// Save timing
@@ -145,10 +142,10 @@ namespace OpenRA.LLMHarness.Services
 				total_pipeline_seconds = totalPipelineSeconds
 			};
 			File.WriteAllText(
-				Path.Combine(turnPath, "timing.json"),
+				Path.Combine(currentSessionPath!, $"{timestamp}_timing.json"),
 				JsonSerializer.Serialize(timing, new JsonSerializerOptions { WriteIndented = true }));
 
-			return turnPath;
+			return currentSessionPath!;
 		}
 
 		public void CleanupOrphanedMarker()

--- a/OpenRA.LLMHarness/appsettings.json
+++ b/OpenRA.LLMHarness/appsettings.json
@@ -11,6 +11,7 @@
     "LogDirectory": "C:\\OpenRATest\\LLM_Coach_Logs",
     "OrderInputDirectory": "C:\\OpenRATest_Orders\\input",
     "OrderArchiveDirectory": "C:\\OpenRATest_Orders\\archive",
+    "SessionsDirectory": "sessions",
     "OllamaApiUrl": "http://localhost:11434/v1",
     "ModelName": "phi4:14b"
   }

--- a/OpenRA.Mods.Common/Traits/World/GameStateExporter.cs
+++ b/OpenRA.Mods.Common/Traits/World/GameStateExporter.cs
@@ -62,7 +62,7 @@ namespace OpenRA.Mods.Common.Traits
 			if (world.WorldTick == 2)
 			{
 				// Check if this is a new map/game
-				if (hasArchivedForThisGame)
+				if (!hasArchivedForThisGame)
 				{
 					ArchivePreviousGameFiles();
 					hasArchivedForThisGame = true;
@@ -100,8 +100,8 @@ namespace OpenRA.Mods.Common.Traits
 				if (!Directory.Exists(info.OutputDirectory))
 					return;
 
-				var gameStateFiles = Directory.GetFiles(info.OutputDirectory, "gamestate_*.txt");
-				if (gameStateFiles.Length == 0)
+				var currentGameStateFile = Path.Combine(info.OutputDirectory, "current_gamestate.txt");
+				if (!File.Exists(currentGameStateFile))
 					return;
 
 				var archiveDirectory = Path.Combine(info.OutputDirectory, "archive");
@@ -112,14 +112,10 @@ namespace OpenRA.Mods.Common.Traits
 				var gameArchiveDirectory = Path.Combine(archiveDirectory, $"game_{timestamp}");
 				Directory.CreateDirectory(gameArchiveDirectory);
 
-				foreach (var file in gameStateFiles)
-				{
-					var fileName = Path.GetFileName(file);
-					var destinationPath = Path.Combine(gameArchiveDirectory, fileName);
-					File.Move(file, destinationPath);
-				}
+				var destinationPath = Path.Combine(gameArchiveDirectory, "current_gamestate.txt");
+				File.Move(currentGameStateFile, destinationPath);
 
-				Log.Write("debug", $"Archived {gameStateFiles.Length} gamestate files to {gameArchiveDirectory}");
+				Log.Write("debug", $"Archived current gamestate file to {gameArchiveDirectory}");
 			}
 			catch (Exception e)
 			{
@@ -403,17 +399,26 @@ namespace OpenRA.Mods.Common.Traits
 		{
 			try
 			{
+				// Check if a session is active by looking for the session marker file
+				var sessionMarkerFile = Path.Combine(info.OutputDirectory, ".session_active");
+				if (!File.Exists(sessionMarkerFile))
+				{
+					Log.Write("debug", "[GameStateExporter] Skipping export - no active session (marker file not found)");
+					return;
+				}
+
 				// Auto-place any ready buildings before exporting state
 				AutoPlaceReadyBuildings();
 
 				if (!Directory.Exists(info.OutputDirectory))
 					Directory.CreateDirectory(info.OutputDirectory);
 
-				var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss", CultureInfo.InvariantCulture);
+				// Use single filename instead of timestamped files
+				var filename = Path.Combine(info.OutputDirectory, "current_gamestate.txt");
+
 				var totalSeconds = world.WorldTick / 25;
 			var minutes = totalSeconds / 60;
 			var seconds = totalSeconds % 60;
-			var filename = Path.Combine(info.OutputDirectory, $"gamestate_{timestamp}_{minutes:D2}m{seconds:D2}s.txt");
 
 				var sb = new StringBuilder();
 				sb.AppendLine("# Game State Snapshot");


### PR DESCRIPTION
## Summary

This PR redesigns the file IPC system from first principles to address flaky file processing and enable better research collaboration:

- **Manual session management**: Start/Stop buttons in LLM Harness UI
- **Session-based artifact storage**: Sessions saved in `OpenRA.LLMHarness/sessions/YYYYMMDD_HHMMSS_{guid}/`
- **Per-turn artifact files**: System prompt, user message, assistant response, settings, and timing saved as separate markdown/JSON files
- **Single gamestate file**: Changed from timestamped accumulation to single `current_gamestate.txt` that overwrites
- **Git-friendly structure**: Sessions in project root for easy collaboration and version control
- **Configurable paths**: All directories configured via appsettings.json
- **Compact sidebar UI**: Dense MudBlazor list for session history

## Key Changes

### Session Management
- Created `SessionManager` service for manual session lifecycle control
- Added Start/Stop Session UI controls in LLM Harness
- Sessions stored as `YYYYMMDD_HHMMSS_{shortguid}/` folders with per-turn timestamped files
- Session marker file coordinates game/harness synchronization

### File Processing
- GameStateExporter now writes to single `current_gamestate.txt` instead of timestamped files
- Fixed archiving bug (inverted boolean condition)
- Added session marker check before exporting
- Fixed file processing loop to detect file updates via timestamp tracking

### Turn Artifact Storage
Each turn saves:
- `YYYYMMDD_HHmmss_system_prompt.md`
- `YYYYMMDD_HHmmss_user_message.md`
- `YYYYMMDD_HHmmss_assistant_response.md`
- `YYYYMMDD_HHmmss_settings.json` (model, thinking level, turn number)
- `YYYYMMDD_HHmmss_timing.json` (latency and pipeline metrics)

### UI Improvements
- Replaced nested MudCard components with canonical Dense MudBlazor list
- Compact single-line format: `HH:mm:ss - X.Xs`
- Built-in selection highlighting

## Benefits

✅ Eliminates flaky file processing on startup  
✅ Reproducible research sessions with git-friendly structure  
✅ Clear session boundaries with manual control  
✅ Per-turn model tracking for mixed-model experiments  
✅ Complete artifact preservation for reconstruction  
✅ Cleaner, more compact UI  

## Testing

- Built successfully in Release mode
- File processing loop works continuously through entire match
- Sessions created in correct location (`OpenRA.LLMHarness/sessions/`)
- Turn artifacts saved with proper timestamped filenames

🤖 Generated with [Claude Code](https://claude.com/claude-code)